### PR TITLE
Add libmagic1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -36,6 +36,7 @@ run apt-get update \
         jq \
         libffi-dev \
         libreadline-dev \
+	libmagic1 \
 	# git: get the semi-official latest-stable git instead of using the old(er) version from the
 	# ubuntu distro
 	&& add-apt-repository ppa:git-core/ppa \


### PR DESCRIPTION
Needed for one of our projects.

Installing apt dependencies in CircleCI fails with and without sudo, possibly due to `rm -rf /var/lib/apt/lists/*`. I'm not sure if the intent of this image was to forbid further package installs, but apt install without suod complains about missing `/var/lib/apt/lists/partial`.